### PR TITLE
Fix bug for Changing Password #9

### DIFF
--- a/Tella.xcodeproj/project.pbxproj
+++ b/Tella.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		6DC2ABCB24502D08004579DF /* ChangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC2ABCA24502D08004579DF /* ChangeView.swift */; };
 		6DD4C038240F4B9900491438 /* PreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD4C037240F4B9900491438 /* PreviewView.swift */; };
 		6DD4C03A240F547300491438 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD4C039240F547300491438 /* Util.swift */; };
+		CE02ED7F24E42B3900014176 /* UserDefaultsProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE02ED7E24E42B3900014176 /* UserDefaultsProperty.swift */; };
 		E12CB8DB2EF4EAB5A7E30A55 /* libPods-Tella.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 709EB4248F0BF4B28B960244 /* libPods-Tella.a */; };
 		F66E65AD23E3207D000F93E5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F66E65AC23E3207D000F93E5 /* AppDelegate.swift */; };
 		F66E65AF23E3207D000F93E5 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F66E65AE23E3207D000F93E5 /* SceneDelegate.swift */; };
@@ -80,6 +81,7 @@
 		709EB4248F0BF4B28B960244 /* libPods-Tella.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tella.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D0CF24AE4FC6E195219D930 /* libPods-TellaTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TellaTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		94A8BE7F6F79CE94D48D50AF /* Pods-Tella-TellaUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tella-TellaUITests.release.xcconfig"; path = "Target Support Files/Pods-Tella-TellaUITests/Pods-Tella-TellaUITests.release.xcconfig"; sourceTree = "<group>"; };
+		CE02ED7E24E42B3900014176 /* UserDefaultsProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsProperty.swift; sourceTree = "<group>"; };
 		DCC471E11330CF394E9313E0 /* Pods-TellaTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TellaTests.release.xcconfig"; path = "Target Support Files/Pods-TellaTests/Pods-TellaTests.release.xcconfig"; sourceTree = "<group>"; };
 		F66E65A923E3207D000F93E5 /* Tella.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tella.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F66E65AC23E3207D000F93E5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 				6D848FA22416D12D004896E0 /* CryptoManager.swift */,
 				6DC2ABC8245029BC004579DF /* PasswordView.swift */,
 				6DC2ABCA24502D08004579DF /* ChangeView.swift */,
+				CE02ED7E24E42B3900014176 /* UserDefaultsProperty.swift */,
 			);
 			path = Tella;
 			sourceTree = "<group>";
@@ -459,6 +462,7 @@
 				6D14AADA2405AC1B0094D71D /* FileManager.swift in Sources */,
 				6D848FA32416D12D004896E0 /* CryptoManager.swift in Sources */,
 				F66E65AF23E3207D000F93E5 /* SceneDelegate.swift in Sources */,
+				CE02ED7F24E42B3900014176 /* UserDefaultsProperty.swift in Sources */,
 				6DD4C03A240F547300491438 /* Util.swift in Sources */,
 				F66E65B123E3207D000F93E5 /* ContentView.swift in Sources */,
 				6D14AAD823FB0B310094D71D /* GalleryView.swift in Sources */,

--- a/Tella/ChangeView.swift
+++ b/Tella/ChangeView.swift
@@ -29,7 +29,7 @@ struct ChangeView: View {
             Spacer().frame(height: 30)
 
             VStack {
-                ForEach(Array(zip(PasswordView.passwordTypes.indices, PasswordView.passwordTypes)), id: \.0) { index, type in
+                ForEach(Array(zip(PasswordTypeEnum.allCases.indices, PasswordTypeEnum.allCases)), id: \.0) { index, type in
                     Group {
                         if index > 0 {
                             Spacer().frame(height: 10)

--- a/Tella/ChangeView.swift
+++ b/Tella/ChangeView.swift
@@ -34,10 +34,11 @@ struct ChangeView: View {
                         if index > 0 {
                             Spacer().frame(height: 10)
                         }
-                        roundedChangePasswordButton(type.buttonText, self.privateKey, type) { isSuccess in
-                            if isSuccess {
+                        RoundedButton(text: type.buttonText) {
+                            do {
+                                try CryptoManager.updateKeys(self.privateKey, type)
                                 self.back()
-                            } else {
+                            } catch {
                                 self.isAlertVisible = true
                             }
                         }

--- a/Tella/ChangeView.swift
+++ b/Tella/ChangeView.swift
@@ -17,19 +17,50 @@ struct ChangeView: View {
     
     let back: () -> ()
     let privateKey: SecKey
+
+    @State private var isAlertVisible = false
+
+    private static let passwordTypes: [PasswordTypeEnum] = [.PASSWORD, .PASSCODE, .BIOMETRIC]
     
     var body: some View {
-        return VStack {
+        VStack {
+            header(backButton { self.back() })
             bigText("TELLA", true)
             Spacer()
             smallText("Change lock type:")
             Spacer().frame(height: 30)
-            roundedChangePasswordButton("        Password        ", self.privateKey, .PASSWORD, self.back)
-            Spacer().frame(height: 10)
-            roundedChangePasswordButton("  Phone Passcode  ", self.privateKey, .PASSCODE, self.back)
-            Spacer().frame(height: 10)
-            roundedChangePasswordButton(" Phone Biometrics ", self.privateKey, .BIOMETRIC, self.back)
+
+            VStack {
+                ForEach(Array(zip(Self.passwordTypes.indices, Self.passwordTypes)), id: \.0) { index, type in
+                    Group {
+                        if index > 0 {
+                            Spacer().frame(height: 10)
+                        }
+                        roundedChangePasswordButton(type.buttonText, self.privateKey, type) { isSuccess in
+                            if isSuccess {
+                                self.back()
+                            } else {
+                                self.isAlertVisible = true
+                            }
+                        }
+                    }
+                }
+            }
+                .fixedSize()
             Spacer()
+        }
+        .alert(isPresented: $isAlertVisible) {
+            Alert(title: Text("Failed to change lock"))
+        }
+    }
+}
+
+private extension PasswordTypeEnum {
+    var buttonText: String {
+        switch self {
+        case .PASSWORD: return "Password"
+        case .PASSCODE: return " Phone Passcode"
+        case .BIOMETRIC: return "Phone Biometrics"
         }
     }
 }

--- a/Tella/ChangeView.swift
+++ b/Tella/ChangeView.swift
@@ -19,8 +19,6 @@ struct ChangeView: View {
     let privateKey: SecKey
 
     @State private var isAlertVisible = false
-
-    private static let passwordTypes: [PasswordTypeEnum] = [.PASSWORD, .PASSCODE, .BIOMETRIC]
     
     var body: some View {
         VStack {
@@ -31,7 +29,7 @@ struct ChangeView: View {
             Spacer().frame(height: 30)
 
             VStack {
-                ForEach(Array(zip(Self.passwordTypes.indices, Self.passwordTypes)), id: \.0) { index, type in
+                ForEach(Array(zip(PasswordView.passwordTypes.indices, PasswordView.passwordTypes)), id: \.0) { index, type in
                     Group {
                         if index > 0 {
                             Spacer().frame(height: 10)
@@ -51,16 +49,6 @@ struct ChangeView: View {
         }
         .alert(isPresented: $isAlertVisible) {
             Alert(title: Text("Failed to change lock"))
-        }
-    }
-}
-
-private extension PasswordTypeEnum {
-    var buttonText: String {
-        switch self {
-        case .PASSWORD: return "Password"
-        case .PASSCODE: return " Phone Passcode"
-        case .BIOMETRIC: return "Phone Biometrics"
         }
     }
 }

--- a/Tella/Components.swift
+++ b/Tella/Components.swift
@@ -176,12 +176,18 @@ func roundedButton(_ text: String, _ onClick: @escaping () -> ()) -> AnyView {
     })
 }
 
-func roundedInitPasswordButton(_ text: String, _ type: PasswordTypeEnum, _ back: @escaping () -> ()) -> AnyView {
+func roundedInitPasswordButton(
+    _ text: String,
+    _ type: PasswordTypeEnum,
+    _ completion: @escaping (Bool) -> Void) -> AnyView {
+
     return roundedButton(text) {
         do {
             try CryptoManager.initKeys(type)
-            back()
-        } catch {}
+            completion(true)
+        } catch {
+            completion(false)
+        }
     }
 }
 
@@ -189,14 +195,14 @@ func roundedChangePasswordButton(
     _ text: String,
     _ privateKey: SecKey,
     _ type: PasswordTypeEnum,
-    _ back: @escaping (Bool) -> Void) -> AnyView {
+    _ completion: @escaping (Bool) -> Void) -> AnyView {
 
     return roundedButton(text) {
         do {
             try CryptoManager.updateKeys(privateKey, type)
-            back(true)
+            completion(true)
         } catch {
-            back(false)
+            completion(false)
         }
     }
 }

--- a/Tella/Components.swift
+++ b/Tella/Components.swift
@@ -160,49 +160,19 @@ func previewHeader(_ back: Button<AnyView>, _ title: String) -> AnyView {
     })
 }
 
+struct RoundedButton: View {
+    let text: String
+    let onClick: () -> Void
 
-func roundedButton(_ text: String, _ onClick: @escaping () -> ()) -> AnyView {
-
-    return AnyView(Button(action: {
-        onClick()
-    }) {
-        smallText(text)
-            .padding(EdgeInsets(vertical: 10, horizontal: 20))
-            .frame(maxWidth: .infinity)
-            .overlay(
-                RoundedRectangle(cornerRadius: 30)
-                    .stroke(Color.white, lineWidth: 0.5)
-            )
-    })
-}
-
-func roundedInitPasswordButton(
-    _ text: String,
-    _ type: PasswordTypeEnum,
-    _ completion: @escaping (Bool) -> Void) -> AnyView {
-
-    return roundedButton(text) {
-        do {
-            try CryptoManager.initKeys(type)
-            completion(true)
-        } catch {
-            completion(false)
-        }
-    }
-}
-
-func roundedChangePasswordButton(
-    _ text: String,
-    _ privateKey: SecKey,
-    _ type: PasswordTypeEnum,
-    _ completion: @escaping (Bool) -> Void) -> AnyView {
-
-    return roundedButton(text) {
-        do {
-            try CryptoManager.updateKeys(privateKey, type)
-            completion(true)
-        } catch {
-            completion(false)
+    var body: some View {
+        Button(action: onClick) {
+            smallText(text)
+                .padding(EdgeInsets(vertical: 10, horizontal: 20))
+                .frame(maxWidth: .infinity)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 30)
+                        .stroke(Color.white, lineWidth: 0.5)
+                )
         }
     }
 }

--- a/Tella/Components.swift
+++ b/Tella/Components.swift
@@ -130,14 +130,22 @@ func doneButton(_ onPress: @escaping () -> ()) -> Button<AnyView> {
 }
 
 //  Navigational elements
-func header(_ back: Button<AnyView>, _ title: String, shutdownWarningPresented: Binding<Bool>) -> AnyView {
-    AnyView(HStack {
+func header(
+    _ back: Button<AnyView>,
+    _ title: String? = nil,
+    shutdownWarningPresented: Binding<Bool>? = nil) -> some View {
+
+    HStack {
         back
         Spacer()
-        mediumText(title)
-        Spacer()
-        shutdown(isPresented: shutdownWarningPresented)
-    })
+        title.map { title in
+            Group {
+                mediumText(title)
+                Spacer()
+            }
+        }
+        shutdownWarningPresented.map { shutdown(isPresented: $0) }
+    }
 }
 
 
@@ -158,11 +166,13 @@ func roundedButton(_ text: String, _ onClick: @escaping () -> ()) -> AnyView {
     return AnyView(Button(action: {
         onClick()
     }) {
-        smallText(text).padding(10)
-        .overlay(
-            RoundedRectangle(cornerRadius: 30)
-                .stroke(Color.white, lineWidth: 0.5)
-        )
+        smallText(text)
+            .padding(EdgeInsets(vertical: 10, horizontal: 20))
+            .frame(maxWidth: .infinity)
+            .overlay(
+                RoundedRectangle(cornerRadius: 30)
+                    .stroke(Color.white, lineWidth: 0.5)
+            )
     })
 }
 
@@ -175,11 +185,18 @@ func roundedInitPasswordButton(_ text: String, _ type: PasswordTypeEnum, _ back:
     }
 }
 
-func roundedChangePasswordButton(_ text: String, _ privateKey: SecKey, _ type: PasswordTypeEnum, _ back: @escaping () -> ()) -> AnyView {
+func roundedChangePasswordButton(
+    _ text: String,
+    _ privateKey: SecKey,
+    _ type: PasswordTypeEnum,
+    _ back: @escaping (Bool) -> Void) -> AnyView {
+
     return roundedButton(text) {
         do {
             try CryptoManager.updateKeys(privateKey, type)
-        } catch {}
-        back()
+            back(true)
+        } catch {
+            back(false)
+        }
     }
 }

--- a/Tella/Enums.swift
+++ b/Tella/Enums.swift
@@ -68,7 +68,6 @@ enum FileTypeEnum: String {
 
 enum KeyEnum {
     case META_PRIVATE
-    case META_PUBLIC
     case PUBLIC
     case PRIVATE
 
@@ -76,8 +75,6 @@ enum KeyEnum {
         switch (self) {
         case .META_PRIVATE:
             return nil
-        case .META_PUBLIC:
-            return .META_PUBLIC
         case .PUBLIC:
             return .PUBLIC
         case .PRIVATE:
@@ -87,13 +84,8 @@ enum KeyEnum {
 }
 
 enum KeyFileEnum: String {
-    case META_PUBLIC = "meta-pub-key.txt"
     case PUBLIC = "pub-key.txt"
     case PRIVATE = "priv-key.txt"
-
-    public func toPath() -> String {
-        return "\(TellaFileManager.rootDir)/keys/\(self.rawValue)"
-    }
 }
 
 enum PasswordTypeEnum: String {

--- a/Tella/Enums.swift
+++ b/Tella/Enums.swift
@@ -88,10 +88,10 @@ enum KeyFileEnum: String {
     case PRIVATE = "priv-key.txt"
 }
 
-enum PasswordTypeEnum: String {
-    case BIOMETRIC = "biometric"
-    case PASSWORD = "password"
-    case PASSCODE = "passcode"
+enum PasswordTypeEnum {
+    case BIOMETRIC
+    case PASSWORD
+    case PASSCODE
 
     public func toFlag() -> SecAccessControlCreateFlags {
         switch(self) {

--- a/Tella/Enums.swift
+++ b/Tella/Enums.swift
@@ -103,6 +103,14 @@ enum PasswordTypeEnum {
             return .devicePasscode
         }
     }
+
+    var buttonText: String {
+        switch self {
+        case .PASSWORD: return "Password"
+        case .PASSCODE: return " Phone Passcode"
+        case .BIOMETRIC: return "Phone Biometrics"
+        }
+    }
 }
 
 enum PreviewViewEnum{

--- a/Tella/Enums.swift
+++ b/Tella/Enums.swift
@@ -88,10 +88,10 @@ enum KeyFileEnum: String {
     case PRIVATE = "priv-key.txt"
 }
 
-enum PasswordTypeEnum {
-    case BIOMETRIC
+enum PasswordTypeEnum: CaseIterable {
     case PASSWORD
     case PASSCODE
+    case BIOMETRIC
 
     public func toFlag() -> SecAccessControlCreateFlags {
         switch(self) {

--- a/Tella/PasswordView.swift
+++ b/Tella/PasswordView.swift
@@ -14,8 +14,6 @@ import SwiftUI
 struct PasswordView: View {
     
     let back: () -> ()
-
-    static let passwordTypes: [PasswordTypeEnum] = [.PASSWORD, .PASSCODE, .BIOMETRIC]
     
     var body: some View {
         return VStack {
@@ -24,7 +22,7 @@ struct PasswordView: View {
             smallText("Choose lock type:")
             Spacer().frame(height: 30)
             VStack {
-                ForEach(Array(zip(Self.passwordTypes.indices, Self.passwordTypes)), id: \.0) { index, type in
+                ForEach(Array(zip(PasswordTypeEnum.allCases.indices, PasswordTypeEnum.allCases)), id: \.0) { index, type in
                     Group {
                         if index > 0 {
                             Spacer().frame(height: 10)

--- a/Tella/PasswordView.swift
+++ b/Tella/PasswordView.swift
@@ -14,6 +14,8 @@ import SwiftUI
 struct PasswordView: View {
     
     let back: () -> ()
+
+    static let passwordTypes: [PasswordTypeEnum] = [.PASSWORD, .PASSCODE, .BIOMETRIC]
     
     var body: some View {
         return VStack {
@@ -21,11 +23,21 @@ struct PasswordView: View {
             Spacer()
             smallText("Choose lock type:")
             Spacer().frame(height: 30)
-            roundedInitPasswordButton("        Password        ", .PASSWORD, self.back)
-            Spacer().frame(height: 10)
-            roundedInitPasswordButton("  Phone Passcode  ", .PASSCODE, self.back)
-            Spacer().frame(height: 10)
-            roundedInitPasswordButton(" Phone Biometrics ", .BIOMETRIC, self.back)
+            VStack {
+                ForEach(Array(zip(Self.passwordTypes.indices, Self.passwordTypes)), id: \.0) { index, type in
+                    Group {
+                        if index > 0 {
+                            Spacer().frame(height: 10)
+                        }
+                        roundedInitPasswordButton(type.buttonText, type) { isSuccess in
+                            if isSuccess {
+                                self.back()
+                            }
+                        }
+                    }
+                }
+            }
+                .fixedSize()
             Spacer()
         }
     }

--- a/Tella/PasswordView.swift
+++ b/Tella/PasswordView.swift
@@ -16,7 +16,7 @@ struct PasswordView: View {
     let back: () -> ()
     
     var body: some View {
-        return VStack {
+        VStack {
             bigText("TELLA", true)
             Spacer()
             smallText("Choose lock type:")
@@ -27,10 +27,11 @@ struct PasswordView: View {
                         if index > 0 {
                             Spacer().frame(height: 10)
                         }
-                        roundedInitPasswordButton(type.buttonText, type) { isSuccess in
-                            if isSuccess {
+                        RoundedButton(text: type.buttonText) {
+                            do {
+                                try CryptoManager.initKeys(type)
                                 self.back()
-                            }
+                            } catch {}
                         }
                     }
                 }

--- a/Tella/PreviewView.swift
+++ b/Tella/PreviewView.swift
@@ -144,9 +144,10 @@ struct PreviewView: View {
             }
 
             Spacer()
-            roundedButton("EXPORT") {
+            RoundedButton(text: "EXPORT") {
                 self.isSharePresented = self.data != nil
             }
+                .fixedSize()
             .sheet(isPresented: $isSharePresented, onDismiss: {
                 print("Dismiss")
             }, content: {

--- a/Tella/UserDefaultsProperty.swift
+++ b/Tella/UserDefaultsProperty.swift
@@ -1,0 +1,19 @@
+//
+//  UserDefaults.swift
+//  Tella
+//
+//  Created by Rance Tsai on 8/12/20.
+//  Copyright © 2020 Anessa Petteruti. All rights reserved.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefaultsProperty<T> {
+    let key: String
+
+    var wrappedValue: T? {
+        get { UserDefaults.standard.object(forKey: key) as? T }
+        set { UserDefaults.standard.set(newValue, forKey: key) }
+    }
+}

--- a/Tella/Util.swift
+++ b/Tella/Util.swift
@@ -11,6 +11,7 @@
  */
 
 import UIKit
+import SwiftUI
 
 // Taken from here:
 // https://iosdevcenters.blogspot.com/2019/08/ios-image-orientation-before-upload-on.html
@@ -89,5 +90,11 @@ struct RuntimeError: Error {
 
     public var localizedDescription: String {
         return message
+    }
+}
+
+extension EdgeInsets {
+    init(vertical: CGFloat, horizontal: CGFloat) {
+        self.init(top: vertical, leading: horizontal, bottom: vertical, trailing: horizontal)
     }
 }


### PR DESCRIPTION
### Changes
- Append an UUID to application tag of private keys
- Store private/public key files in a directory named the UUID mentioned above
- Delete the old key after the new key is generated
- Remove usage of meta public key file
- Add a back button on `ChangeView`

### Known issues
Deleting key of **application password** might require entering the password again.
The worst case scenario is changing from password A to B.
1. Tap Setting > Change lock, enter A.
2. Tap Password, enter B twice.
3. Enter A for deleting the old key, this step is quite confusing.