### PR TITLE
add deleteAllServers method and deleteAll dbHelper

### DIFF
--- a/Tella/Data/Database/Common/DataBaseHelper.swift
+++ b/Tella/Data/Database/Common/DataBaseHelper.swift
@@ -423,24 +423,30 @@ class DataBaseHelper {
         }
     }
     
-    func deleteAll(tableName:String) throws -> Int {
+    func deleteAll(tableNames: [String]) throws -> Int {
+        var totalDeletedCount = 0
         
-        let deleteSql = "DELETE FROM '\(tableName)'"
-        
-        debugLog("delete: \(deleteSql)")
-        
-        guard let deleteStatement = try prepareStatement(sql: deleteSql) else {
-            throw SqliteError(message: errorMessage)
+        for tableName in tableNames {
+            let deleteSql = "DELETE FROM '\(tableName)'"
+            
+            debugLog("delete: \(deleteSql)")
+            
+            guard let deleteStatement = try prepareStatement(sql: deleteSql) else {
+                throw SqliteError(message: errorMessage)
+            }
+            
+            let deletedCount = self.execute(stmt: deleteStatement, sql: deleteSql)
+            
+            if deletedCount == 0 {
+                throw SqliteError(message: errorMessage)
+            }
+            
+            totalDeletedCount += deletedCount
         }
         
-        let result = self.execute(stmt: deleteStatement, sql: deleteSql)
-        
-        if result == 0 {
-            throw SqliteError(message: errorMessage)
-        }
-        
-        return result
+        return totalDeletedCount
     }
+
     
     
     public func bind(insertStatement: OpaquePointer?, _ values: [KeyValue]) -> OpaquePointer? {

--- a/Tella/Data/Database/Common/DataBaseHelper.swift
+++ b/Tella/Data/Database/Common/DataBaseHelper.swift
@@ -423,6 +423,26 @@ class DataBaseHelper {
         }
     }
     
+    func deleteAll(tableName:String) throws -> Int {
+        
+        let deleteSql = "DELETE FROM '\(tableName)'"
+        
+        debugLog("delete: \(deleteSql)")
+        
+        guard let deleteStatement = try prepareStatement(sql: deleteSql) else {
+            throw SqliteError(message: errorMessage)
+        }
+        
+        let result = self.execute(stmt: deleteStatement, sql: deleteSql)
+        
+        if result == 0 {
+            throw SqliteError(message: errorMessage)
+        }
+        
+        return result
+    }
+    
+    
     public func bind(insertStatement: OpaquePointer?, _ values: [KeyValue]) -> OpaquePointer? {
         
         for keyValue in values {

--- a/Tella/Data/Database/TellaData.swift
+++ b/Tella/Data/Database/TellaData.swift
@@ -56,6 +56,17 @@ class TellaData : ObservableObject {
         return id
         
     }
+
+    func deleteAllServers() throws -> Int {
+        
+        guard let database = database else {
+            throw SqliteError()
+        }
+        let id = try database.deleteAllServers()
+        getServers()
+        return id
+        
+    }
     
     func getServers(){
         guard let database = database else {

--- a/Tella/Data/Database/TellaDataBase.swift
+++ b/Tella/Data/Database/TellaDataBase.swift
@@ -191,6 +191,10 @@ class TellaDataBase {
         return try dataBaseHelper.delete(tableName: D.tServer,
                                          primarykeyValue: [KeyValue(key: D.cServerId, value: serverId)])
     }
+
+    func deleteAllServers() throws -> Int {
+        return try dataBaseHelper.deleteAll(tableName: D.tServer)
+    }
     
     func getReports(reportStatus:[ReportStatus]) -> [Report] {
         

--- a/Tella/Data/Database/TellaDataBase.swift
+++ b/Tella/Data/Database/TellaDataBase.swift
@@ -193,7 +193,7 @@ class TellaDataBase {
     }
 
     func deleteAllServers() throws -> Int {
-        return try dataBaseHelper.deleteAll(tableName: D.tServer)
+        return try dataBaseHelper.deleteAll(tableNames: [D.tServer, D.tReport, D.tReportInstanceVaultFile])
     }
     
     func getReports(reportStatus:[ReportStatus]) -> [Report] {

--- a/Tella/Scenes/HomeView/Views/Home/HomeView.swift
+++ b/Tella/Scenes/HomeView/Views/Home/HomeView.swift
@@ -51,7 +51,7 @@ struct HomeView: View {
                         
                         if(appModel.settings.deleteServerSettings) {
                             // remove servers connections
-                            serversViewModel.getAllServersConnections()
+                            serversViewModel.deleteAllServersConnection()
                         }
                         
                         appViewState.resetToUnlock()

--- a/Tella/Scenes/HomeView/Views/Home/HomeView.swift
+++ b/Tella/Scenes/HomeView/Views/Home/HomeView.swift
@@ -51,7 +51,7 @@ struct HomeView: View {
                         
                         if(appModel.settings.deleteServerSettings) {
                             // remove servers connections
-                            serversViewModel.deleteServer()
+                            serversViewModel.getAllServersConnections()
                         }
                         
                         appViewState.resetToUnlock()

--- a/Tella/Scenes/Settings/ViewModel/ServersViewModel.swift
+++ b/Tella/Scenes/Settings/ViewModel/ServersViewModel.swift
@@ -34,4 +34,12 @@ class ServersViewModel: ObservableObject {
         } catch {
         }
     }
+    
+    func getAllServersConnections() {
+        // call function deleteAllServers
+        do {
+            _ = try mainAppModel.vaultManager.tellaData.deleteAllServers()
+        } catch {
+        }
+    }
 }

--- a/Tella/Scenes/Settings/ViewModel/ServersViewModel.swift
+++ b/Tella/Scenes/Settings/ViewModel/ServersViewModel.swift
@@ -35,8 +35,7 @@ class ServersViewModel: ObservableObject {
         }
     }
     
-    func getAllServersConnections() {
-        // call function deleteAllServers
+    func deleteAllServersConnection() {
         do {
             _ = try mainAppModel.vaultManager.tellaData.deleteAllServers()
         } catch {


### PR DESCRIPTION
For more information on contributing to Tella source code, see the [Contributor Guidelines](contributing/contributor_guide.md).

## Type of change
bug fix

**Description:**
The quick delete button was using a method that only remove one server. Now it removes all of the servers connections that were connected

**Select the type of change(s) made in this pull request:**
- [ ] Bug fix *(Fixes an issue)*
- [ ] New feature *(Adds functionality)*
- [ ] Documentation *(Fix to documentation)*

https://www.loom.com/share/55bed38aa2d84a25bfb0c80cf9857889
