### PR TITLE
Fix issue with app crashing after opening the camera

### DIFF
--- a/Tella/Scenes/Camera/Views/CameraView.swift
+++ b/Tella/Scenes/Camera/Views/CameraView.swift
@@ -121,6 +121,7 @@ struct CameraView: View {
             model.stopRunningCaptureSession()
         })
         .edgesIgnoringSafeArea(.all)
+        .environmentObject(cameraViewModel)
         
     }
     


### PR DESCRIPTION
For more information on contributing to Tella source code, see the [Contributor Guidelines](contributing/contributor_guide.md).

## Type of change

This PR will solve the issue that the app crashes when user opens the camera feature.


**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(Fixes an issue)*
- [ ] New feature *(Adds functionality)*
- [ ] Documentation *(Fix to documentation)*

----------------------------------------------------------------------------------------


## Proposed changes 
- Made changes that prevents the app from crashing when the user open the camera feature
