### PR TITLE
Character limit in Uwazi login screen fields

### DIFF
--- a/Tella/Components/TextfieldView.swift
+++ b/Tella/Components/TextfieldView.swift
@@ -11,8 +11,6 @@ enum FieldType {
     case text
     case password
     case code
-    case uwaziUsername
-    case uwaziPassword
 }
 struct TextfieldView : View {
     
@@ -157,10 +155,6 @@ struct TextfieldView : View {
             
         case .code:
             self.isValid = value.codeValidator()
-        case .uwaziUsername:
-            self.isValid = value.validateWithRegex(pattern: Regex.textRegex)
-        case .uwaziPassword:
-            self.isValid = value.validateWithRegex(pattern: Regex.textRegex)
         }
         self.shouldShowError = false
     }

--- a/Tella/Components/TextfieldView.swift
+++ b/Tella/Components/TextfieldView.swift
@@ -5,7 +5,15 @@
 
 import SwiftUI
 import Combine
-
+enum FieldType {
+    case url
+    case username
+    case text
+    case password
+    case code
+    case uwaziUsername
+    case uwaziPassword
+}
 struct TextfieldView : View {
     
     @Binding var fieldContent : String
@@ -149,6 +157,10 @@ struct TextfieldView : View {
             
         case .code:
             self.isValid = value.codeValidator()
+        case .uwaziUsername:
+            self.isValid = value.uwaziUsernameValidator()
+        case .uwaziPassword:
+            self.isValid = value.uwaziPasswordValidator()
         }
         self.shouldShowError = false
     }
@@ -178,11 +190,3 @@ struct TextfieldView_Previews: PreviewProvider {
     }
 }
 
-
-enum FieldType {
-    case url
-    case username
-    case text
-    case password
-    case code
-}

--- a/Tella/Components/TextfieldView.swift
+++ b/Tella/Components/TextfieldView.swift
@@ -158,9 +158,9 @@ struct TextfieldView : View {
         case .code:
             self.isValid = value.codeValidator()
         case .uwaziUsername:
-            self.isValid = value.uwaziUsernameValidator()
+            self.isValid = value.validateWithRegex(pattern: Regex.textRegex)
         case .uwaziPassword:
-            self.isValid = value.uwaziPasswordValidator()
+            self.isValid = value.validateWithRegex(pattern: Regex.textRegex)
         }
         self.shouldShowError = false
     }

--- a/Tella/Scenes/Settings/Views/Servers/Uwazi/Step3/UwaziLoginView.swift
+++ b/Tella/Scenes/Settings/Views/Servers/Uwazi/Step3/UwaziLoginView.swift
@@ -58,7 +58,7 @@ struct UwaziLoginView: View {
         return TextfieldView(fieldContent: $uwaziServerViewModel.username,
                              isValid: $uwaziServerViewModel.validUsername,
                              shouldShowError: $uwaziServerViewModel.shouldShowLoginError,
-                             fieldType: .uwaziUsername,
+                             fieldType: .text,
                              placeholder : LocalizableSettings.UwaziUsername.localized)
         .autocapitalization(.none)
         .frame(height: 30)
@@ -69,7 +69,7 @@ struct UwaziLoginView: View {
                              isValid: $uwaziServerViewModel.validPassword,
                              shouldShowError: $uwaziServerViewModel.shouldShowLoginError,
                              errorMessage: uwaziServerViewModel.loginErrorMessage,
-                             fieldType: .uwaziPassword,
+                             fieldType: .text,
                              placeholder : LocalizableSettings.UwaziPassword.localized)
         .autocapitalization(.none)
         .frame(height: 57)

--- a/Tella/Scenes/Settings/Views/Servers/Uwazi/Step3/UwaziLoginView.swift
+++ b/Tella/Scenes/Settings/Views/Servers/Uwazi/Step3/UwaziLoginView.swift
@@ -58,7 +58,7 @@ struct UwaziLoginView: View {
         return TextfieldView(fieldContent: $uwaziServerViewModel.username,
                              isValid: $uwaziServerViewModel.validUsername,
                              shouldShowError: $uwaziServerViewModel.shouldShowLoginError,
-                             fieldType: .username,
+                             fieldType: .uwaziUsername,
                              placeholder : LocalizableSettings.UwaziUsername.localized)
         .autocapitalization(.none)
         .frame(height: 30)
@@ -69,7 +69,7 @@ struct UwaziLoginView: View {
                              isValid: $uwaziServerViewModel.validPassword,
                              shouldShowError: $uwaziServerViewModel.shouldShowLoginError,
                              errorMessage: uwaziServerViewModel.loginErrorMessage,
-                             fieldType: .password,
+                             fieldType: .uwaziPassword,
                              placeholder : LocalizableSettings.UwaziPassword.localized)
         .autocapitalization(.none)
         .frame(height: 57)

--- a/Tella/Utils/Validator.swift
+++ b/Tella/Utils/Validator.swift
@@ -74,24 +74,23 @@ extension String {
         }
         return true
     }
-    func uwaziUsernameValidator() -> Bool {
+    func validateWithRegex(pattern: String) -> Bool {
         guard !self.isEmpty else {
             return false
         }
-        guard validateRegex(value: self, pattern: Regex.textRegex) else {
+        guard validateRegex(value: self, pattern: pattern) else {
             return false
         }
         return true
     }
-    func uwaziPasswordValidator() -> Bool {
+    func uwaziLoginValidtor() -> Bool {
         guard !self.isEmpty else {
             return false
         }
-        guard validateRegex(value: self, pattern: Regex.textRegex) else {
+        guard validateRegex(value: self, pattern:  Regex.textRegex) else {
             return false
         }
         return true
     }
-
 }
 

--- a/Tella/Utils/Validator.swift
+++ b/Tella/Utils/Validator.swift
@@ -74,14 +74,5 @@ extension String {
         }
         return true
     }
-    func validateWithRegex(pattern: String) -> Bool {
-        guard !self.isEmpty else {
-            return false
-        }
-        guard validateRegex(value: self, pattern: pattern) else {
-            return false
-        }
-        return true
-    }
 }
 

--- a/Tella/Utils/Validator.swift
+++ b/Tella/Utils/Validator.swift
@@ -74,6 +74,24 @@ extension String {
         }
         return true
     }
+    func uwaziUsernameValidator() -> Bool {
+        guard !self.isEmpty else {
+            return false
+        }
+        guard validateRegex(value: self, pattern: Regex.textRegex) else {
+            return false
+        }
+        return true
+    }
+    func uwaziPasswordValidator() -> Bool {
+        guard !self.isEmpty else {
+            return false
+        }
+        guard validateRegex(value: self, pattern: Regex.textRegex) else {
+            return false
+        }
+        return true
+    }
 
 }
 

--- a/Tella/Utils/Validator.swift
+++ b/Tella/Utils/Validator.swift
@@ -83,14 +83,5 @@ extension String {
         }
         return true
     }
-    func uwaziLoginValidtor() -> Bool {
-        guard !self.isEmpty else {
-            return false
-        }
-        guard validateRegex(value: self, pattern:  Regex.textRegex) else {
-            return false
-        }
-        return true
-    }
 }
 


### PR DESCRIPTION
For more information on contributing to Tella source code, see the [Contributor Guidelines](contributing/contributor_guide.md).

## Type of change
Remove the limitation of character in Uwazi login's username and password textfield so that it will enable the login button when at least 1 character each is inserted in both field.



**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(Fixes an issue)*
- [ ] New feature *(Adds functionality)*
- [ ] Documentation *(Fix to documentation)*

----------------------------------------------------------------------------------------


## Proposed changes 
<!-- Describe the changes the PR makes. -->

- Added validator for uwazi username and password validation
- Added new enum uwaziUsername and uwaziPassword for validation 
- Change the fieldType of username and password to uwaziUsername and uwaziPassword
